### PR TITLE
feat: update the methodology of determining performance vs efficiency cores

### DIFF
--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -86,22 +86,42 @@ func GetCPU() (*CPU, error) {
 		return nil, err
 	}
 
-	var pCores, eCores, pThreads, eThreads int
+	type coreInfo struct {
+		efficiencyClass byte
+		threadCount     int
+	}
+	var cores []coreInfo
+	var maxEffClass byte
+
 	offset := 0
 	for offset < len(buf) {
 		header := (*SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(unsafe.Pointer(&buf[offset]))
 		if header.Relationship == relationProcessorCore {
 			pr := (*PROCESSOR_RELATIONSHIP)(unsafe.Add(unsafe.Pointer(&buf[offset]), unsafe.Sizeof(*header)))
-			threadCount := bits.OnesCount64(pr.ProcessorMask)
-			if pr.Flags&1 != 0 {
-				pCores++
-				pThreads += threadCount
-			} else {
-				eCores++
-				eThreads += threadCount
+			ci := coreInfo{
+				efficiencyClass: pr.EfficiencyClass,
+				threadCount:     bits.OnesCount64(pr.ProcessorMask),
 			}
+			if ci.efficiencyClass > maxEffClass {
+				maxEffClass = ci.efficiencyClass
+			}
+			cores = append(cores, ci)
 		}
 		offset += int(header.Size)
+	}
+
+	// Classify cores. Cores with the highest EfficiencyClass are
+	// performance cores; all others are efficiency cores. On homogeneous CPUs
+	// (all cores same class), every core is treated as a performance core.
+	var pCores, eCores, pThreads, eThreads int
+	for _, ci := range cores {
+		if ci.efficiencyClass == maxEffClass {
+			pCores++
+			pThreads += ci.threadCount
+		} else {
+			eCores++
+			eThreads += ci.threadCount
+		}
 	}
 
 	// try to fetch brand string from registry

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -48,6 +48,31 @@ type PROCESSOR_RELATIONSHIP struct {
 	ProcessorMask   uint64
 }
 
+// windowsInfoProvider abstracts the Windows system calls used by GetCPU,
+// allowing for dependency injection in tests.
+type windowsInfoProvider interface {
+	getLogicalProcessorInfoBuf() ([]byte, error)
+	getProcessorBrandString() string
+}
+
+type nativeWindowsProvider struct{}
+
+func (nativeWindowsProvider) getLogicalProcessorInfoBuf() ([]byte, error) {
+	return getLogicalProcessorInfo()
+}
+
+func (nativeWindowsProvider) getProcessorBrandString() string {
+	if k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE); err == nil {
+		defer k.Close()
+		if s, _, err2 := k.GetStringValue("ProcessorNameString"); err2 == nil {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+var winsys windowsInfoProvider = nativeWindowsProvider{}
+
 // getLogicalProcessorInfo calls the Windows API and returns the raw buffer.
 func getLogicalProcessorInfo() ([]byte, error) {
 	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
@@ -81,7 +106,7 @@ func getLogicalProcessorInfo() ([]byte, error) {
 // performance and efficiency cores and threads, and reads the processor name
 // from the registry if available.
 func GetCPU() (*CPU, error) {
-	buf, err := getLogicalProcessorInfo()
+	buf, err := winsys.getLogicalProcessorInfoBuf()
 	if err != nil {
 		return nil, err
 	}
@@ -124,14 +149,7 @@ func GetCPU() (*CPU, error) {
 		}
 	}
 
-	// try to fetch brand string from registry
-	var brand string
-	if k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE); err == nil {
-		if s, _, err2 := k.GetStringValue("ProcessorNameString"); err2 == nil {
-			brand = strings.TrimSpace(s)
-		}
-		k.Close()
-	}
+	brand := winsys.getProcessorBrandString()
 
 	return &CPU{
 		BrandString:              brand,

--- a/cpu_windows_test.go
+++ b/cpu_windows_test.go
@@ -1,0 +1,144 @@
+//go:build windows
+
+package xpe
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+type mockWindowsProvider struct {
+	buf   []byte
+	brand string
+}
+
+func (m *mockWindowsProvider) getLogicalProcessorInfoBuf() ([]byte, error) {
+	return m.buf, nil
+}
+
+func (m *mockWindowsProvider) getProcessorBrandString() string {
+	return m.brand
+}
+
+type testCore struct {
+	efficiencyClass byte
+	threadMask      uint64
+}
+
+// buildProcessorInfoBuf constructs a raw byte buffer matching the layout that
+// GetLogicalProcessorInformationEx returns, from a slice of core descriptors.
+func buildProcessorInfoBuf(t *testing.T, cores []testCore) []byte {
+	t.Helper()
+
+	headerSize := unsafe.Sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX{})
+	prSize := unsafe.Sizeof(PROCESSOR_RELATIONSHIP{})
+	entrySize := uint32(headerSize + prSize)
+
+	var buf []byte
+	for _, c := range cores {
+		entry := make([]byte, entrySize)
+		header := (*SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(unsafe.Pointer(&entry[0]))
+		header.Relationship = relationProcessorCore
+		header.Size = entrySize
+
+		pr := (*PROCESSOR_RELATIONSHIP)(unsafe.Pointer(&entry[headerSize]))
+		pr.EfficiencyClass = c.efficiencyClass
+		pr.ProcessorMask = c.threadMask
+
+		buf = append(buf, entry...)
+	}
+	return buf
+}
+
+// repeat creates n copies of the given testCore.
+func repeat(n int, c testCore) []testCore {
+	cores := make([]testCore, n)
+	for i := range cores {
+		cores[i] = c
+	}
+	return cores
+}
+
+func TestGetCPU_Windows(t *testing.T) {
+	tests := []struct {
+		name  string
+		cores []testCore
+		brand string
+		want  *CPU
+	}{
+		{
+			name:  "Intel 13th Gen hybrid (8P HT + 8E)",
+			cores: append(repeat(8, testCore{1, 0x3}), repeat(8, testCore{0, 0x1})...),
+			brand: "13th Gen Intel(R) Core(TM) i7-13700K",
+			want: &CPU{
+				BrandString:              "13th Gen Intel(R) Core(TM) i7-13700K",
+				Threads:                  24,
+				Cores:                    16,
+				LogicalPerformanceCores:  16,
+				LogicalEfficiencyCores:   8,
+				PhysicalPerformanceCores: 8,
+				PhysicalEfficiencyCores:  8,
+			},
+		},
+		{
+			name:  "Homogeneous Intel (8 cores HT, all same efficiency class)",
+			cores: repeat(8, testCore{0, 0x3}),
+			brand: "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+			want: &CPU{
+				BrandString:              "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+				Threads:                  16,
+				Cores:                    8,
+				LogicalPerformanceCores:  16,
+				LogicalEfficiencyCores:   0,
+				PhysicalPerformanceCores: 8,
+				PhysicalEfficiencyCores:  0,
+			},
+		},
+		{
+			name:  "Snapdragon X Elite (8P + 4E, no HT)",
+			cores: append(repeat(8, testCore{1, 0x1}), repeat(4, testCore{0, 0x1})...),
+			brand: "Snapdragon(R) X Elite - X1E78100 - Qualcomm(R) Oryon(TM) CPU",
+			want: &CPU{
+				BrandString:              "Snapdragon(R) X Elite - X1E78100 - Qualcomm(R) Oryon(TM) CPU",
+				Threads:                  12,
+				Cores:                    12,
+				LogicalPerformanceCores:  8,
+				LogicalEfficiencyCores:   4,
+				PhysicalPerformanceCores: 8,
+				PhysicalEfficiencyCores:  4,
+			},
+		},
+		{
+			name:  "Single core CPU",
+			cores: []testCore{{0, 0x1}},
+			brand: "Some Single Core CPU",
+			want: &CPU{
+				BrandString:              "Some Single Core CPU",
+				Threads:                  1,
+				Cores:                    1,
+				LogicalPerformanceCores:  1,
+				LogicalEfficiencyCores:   0,
+				PhysicalPerformanceCores: 1,
+				PhysicalEfficiencyCores:  0,
+			},
+		},
+	}
+
+	defer func() { winsys = nativeWindowsProvider{} }()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			winsys = &mockWindowsProvider{
+				buf:   buildProcessorInfoBuf(t, tt.cores),
+				brand: tt.brand,
+			}
+			got, err := GetCPU()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Fatalf("want %+v, got %+v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Thought I would take a stab at grabbing the right info.

This was the output I got:
```sh
$ go run cmd/main.go
{
  "BrandString": "Intel(R) Core(TM) Ultra 7 255H",
  "Threads": 16,
  "Cores": 16,
  "LogicalPerformanceCores": 6,
  "LogicalEfficiencyCores": 10,
  "PhysicalPerformanceCores": 6,
  "PhysicalEfficiencyCores": 10
}
```